### PR TITLE
fix: build issue on windows machines

### DIFF
--- a/template/package.temp
+++ b/template/package.temp
@@ -93,7 +93,7 @@
     "bundler": "webpack --mode=production",
     "bundle:test": "webpack-dev-server --host 0.0.0.0",
     "postinstall": "node packageScripts/postinstall.js",
-    "cssLint": "stylelint './src/*.css'",
+    "cssLint": "stylelint \"./src/*.css\"",
     "dev": "npm run sassBuild:watch",
     "distJS": "copyfiles -u 1 -V './src/**/*.js' ./dist",
     "sassRender": "sass-render src/*.css -t ./scripts/staticStyles-template.js",


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** https://github.com/AlaskaAirlines/WC-Generator/issues/44

## Summary:

It seems that stylelint is very picky about the distinction between single quotes and double quotes on a Windows environment. This PR adds double quotes to the stylelint command to ensure that `npm run build` will complete successfully on generated components.

## Type of change:

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
