### PR TITLE
Remove IE11 support wording from support page

### DIFF
--- a/docs/browserSupport.md
+++ b/docs/browserSupport.md
@@ -15,29 +15,20 @@ Alaska Airlines currently supports the following browsers for the delivery of st
 | Chrome | Current release | Windows, macOS, iOS, Android |
 | Safari | Current release | macOS, iOS |
 | Firefox | Current release | Windows, macOS, Android |
-| Edge*† | Stable release | Windows 7, Windows 8, Windows 10 |
-| Internet Explorer†† | 11 | Windows 7, Windows 8, Windows 10 |
+| Edge† | Stable release | Windows 7, Windows 8, Windows 10 |
 
-\* The new Microsoft Edge is based on Chromium and was released on January 15, 2020. It is compatible with all supported versions of Windows, and macOS. Downloading the browser will replace the legacy version of Microsoft Edge  on Windows 10 PCs.
-
-† Edge 18 is the final version to support [EdgeHTML](https://en.wikipedia.org/wiki/EdgeHTML) on Windows 10 machines only. There is no directive to individually support this version of Edge.
-
-†† Internet Explorer has been fully deprecated by Microsoft and testing in this browser requires special agreement from Product for the additional effort required to support this browser. It is planned to drop all support for Internet Explorer by Q3 2021.
+† Chromium based Microsoft Edge was released on January 15, 2020. Edge 18, the final version based on [EdgeHTML](https://en.wikipedia.org/wiki/EdgeHTML) on Windows 10 machines only, is NOT supported.
 
 #### Browser support for HTML Web Components
 
-| Feature | Chrome | Opera | Safari | Firefox | MS Edge | IE
+| Feature | Chrome | Opera | Safari | Firefox | MS Edge
 |----|----|----|----|----|----|----|----|
-| HTML Templates | Stable | Stable | Stable | Stable | Stable | Transpiling†/Polyfill* |
-| Custom Elements | Stable | Stable | Stable | Stable | Stable | Transpiling†/Polyfill* |
-| Shadow DOM | Stable | Stable | Stable | Stable | Stable | Transpiling†/Polyfill* |
-| ES Modules | Stable | Stable | Stable | Stable | Stable | Transpiling†/Polyfill* |
+| HTML Templates | Stable | Stable | Stable | Stable | Stable
+| Custom Elements | Stable | Stable | Stable | Stable | Stable
+| Shadow DOM | Stable | Stable | Stable | Stable | Stable
+| ES Modules | Stable | Stable | Stable | Stable | Stable
 
-[webcomponents.org](https://www.webcomponents.org/)
-
-† Transpiling from ES6 to ES5 is required for browser support.
-
-\* JavaScript polyfills are required in order for these browsers to render Polymer/Lit-element web components. See the [polyfill doc](https://github.com/AlaskaAirlines/auro/blob/master/src/POLYFILL.md) for more information on installment options.
+-- source: [webcomponents.org](https://www.webcomponents.org/)
 
 #### Browser support for CSS Custom Properties (variables)
 
@@ -47,7 +38,3 @@ Alaska Airlines currently supports the following browsers for the delivery of st
 | Safari | Current release | Yes |
 | Firefox | Current release | Yes |
 | Edge | Current release | Yes |
-| Internet Explorer | 11 | No* |
-
-\* Fallback CSS is required to support browser. See [Custom Properties doc](https://auro.alaskaair.com/support/custom-properties) for information about setup and configuration.
-


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #39 

## Summary:

This PR updates the browser matrix page that removes language that speaks to Auro's support of the now deprecated IE 11 browser. 

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [x] Other (docs)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
