### PR TITLE
fix(linter): fix no @ rule for scss

### DIFF
--- a/template/.stylelintrc
+++ b/template/.stylelintrc
@@ -17,6 +17,7 @@
       ]
     } ],
     "at-rule-name-newline-after": "always-multi-line",
+    "at-rule-no-unknown": null,
     "at-rule-semicolon-space-before": "never",
     "block-closing-brace-space-after": "always-single-line",
     "block-opening-brace-newline-before": "never-single-line",


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #173

## Summary:

This change sets the default no @ rule linting to `null` so that the SCSS version will work correctly without conflicting.
## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**
-- Auro Design System Team
