### PR TITLE
docs(dev setup): fix bashrc instructions

### DIFF
--- a/docs/devSetupWindows.md
+++ b/docs/devSetupWindows.md
@@ -38,7 +38,7 @@ code .
 This will open VSCode in the folder you're currently in. Add the following line to the bottom of the `.bashrc` file. This will instruct our test runner where to find Chrome.
 
 ```
-CHROME_PATH=/usr/bin/google-chrome
+export CHROME_PATH=/usr/bin/google-chrome
 ```
 
 ## Clone a repo


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #363

## Summary:

The `export` part of the bashrc instructions for windows was missing.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update
