### PR TITLE
fix: moves auro-library in template to dependencies #577

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -20,6 +20,7 @@
     "node": "^[abstractNodeVersion] || ^[abstractNodeVersionNext] "
   },
   "dependencies": {
+    "@aurodesignsystem/auro-library": "",
     "chalk": "",
     "lit": ""
   },
@@ -28,7 +29,6 @@
     "@aurodesignsystem/webcorestylesheets": ""
   },
   "devDependencies": {
-    "@aurodesignsystem/auro-library": "",
     "@aurodesignsystem/design-tokens": "",
     "@aurodesignsystem/webcorestylesheets": "",
     "@aurodesignsystem/eslint-config": "",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Moves Auro Library in the `template` directory  from `devDependencies ` from `dependencies` to avoid installation issues, as originally reported in [#573](https://github.com/AlaskaAirlines/WC-Generator/issues/573).

**Resolves:** #577 

## Summary:

- Moved to `dependencies` within `package.json`
- Regenerated `package.lock`
- Verified `build` and `test` ran successfully

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team