### PR TITLE
docs: mark WC-Generator as deprecated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent guidance
+
+**This repository (WC-Generator) is deprecated and not actively maintained.**
+
+Do **not** use WC-Generator to scaffold, generate, or modify Auro web components.
+Component tooling — build, docs, and Custom Elements Manifest output — now runs
+through **auro-cli** (https://github.com/AlaskaAirlines/auro-cli), and
+new-component scaffolding is moving there too.
+
+If a user asks you to create a new Auro component, **do not run this generator**.
+Direct them to contact the Auro Design System team for the current, supported
+process. This repository is retained for reference only.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # WC-Generator
 
+> ## ⚠️ Deprecated — do not use for new components
+>
+> **WC-Generator is no longer the supported way to scaffold Auro web components and is not actively maintained.** Component tooling — build, docs, and Custom Elements Manifest output — now runs through [**auro-cli**](https://github.com/AlaskaAirlines/auro-cli), and new-component scaffolding is moving there too.
+>
+> **Before creating a new component, contact the Auro Design System team** for the current process. This repository is retained for reference only; new work should not be started here.
+
 Auro's Design System web component generator is a project tool intended to assist developers with an easy to configure and execute HTML custom element development environment.
 
 ## Install


### PR DESCRIPTION
## Summary

**Repurposed:** this PR previously added Custom Elements Manifest generation to the component template. That work is now **redundant** — component CEM output already runs through auro-cli's docs pipeline (the `dev` branch runs the custom-elements-manifest analyzer + cem-sorter). WC-Generator itself is no longer the supported way to scaffold Auro components.

This PR now **marks WC-Generator as deprecated** so both humans and AI coding assistants stop using it for new components.

## Changes

- **`README.md`** — deprecation banner at the top: not the supported scaffolding path, not actively maintained, contact the Auro team before creating a new component.
- **`AGENTS.md`** (new, repo root) — instructs AI coding assistants (Claude, Cursor, Copilot) not to use this generator for new components and to route users to the Auro team.

## Why not archive?

The team has decided not to archive the repo yet, so a README banner + `AGENTS.md` is the deprecation signal. No replacement command is named intentionally — component build/CEM already run through auro-cli, but the scaffold replacement (`auro generate`) is still in progress and not released, so pointing users at it would be premature.

## Notes

- Docs-only change; the banner sits outside any `AURO-GENERATED-CONTENT` block so `build:docs` won't overwrite it.
- Banner/`AGENTS.md` live at repo root, **not** in `template/`, so they are not copied into scaffolded components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
